### PR TITLE
PPB fix

### DIFF
--- a/srecord/input/file/ppb.cc
+++ b/srecord/input/file/ppb.cc
@@ -55,12 +55,14 @@ srecord::input_file_ppb::get_packet(void)
     if (c != 0x01)
         packet_format_error();
     unsigned char hdr[8];
+    unsigned char csum = 0;
     for (int n = 0; n < 8; ++n)
     {
         c = get_char();
         if (c < 0)
             packet_format_error();
         hdr[n] = c;
+        csum += c;
     }
     packet_length = record::decode_big_endian(hdr, 4);
     if (packet_length > sizeof(packet))
@@ -73,7 +75,6 @@ srecord::input_file_ppb::get_packet(void)
         );
     }
     packet_address = record::decode_big_endian(hdr + 4, 4);
-    unsigned char csum = 0;
     for (size_t j = 0; j < packet_length; ++j)
     {
         if (j > 0 && (j % 1024) == 0)

--- a/srecord/input/file/ppb.cc
+++ b/srecord/input/file/ppb.cc
@@ -49,9 +49,16 @@ srecord::input_file_ppb::create(const std::string &filename)
 bool
 srecord::input_file_ppb::get_packet(void)
 {
-    int c = get_char();
-    if (c < 0)
-        return false;
+    int c;
+
+    // skip ASCII prologue (if any)
+    do{
+        c = get_char();
+        if (c < 0)
+            return false;
+        if ((c == '\n') || (c == '\r'))
+            continue;
+    }while(c != 0x01 && c >= ' ' && c < 0x7f);
     if (c != 0x01)
         packet_format_error();
     unsigned char hdr[8];

--- a/srecord/input/file/ppb.h
+++ b/srecord/input/file/ppb.h
@@ -93,7 +93,7 @@ private:
       * The packet instance variable is used to remember the most recent
       * #packet_length data bytes read from the file in the most recent packet.
       */
-    record::data_t packet[8192];
+    record::data_t packet[65536];
 
     /**
       * The packet_length instance variable is used to remember the


### PR DESCRIPTION
Fixes a few issues with STAG Prom programmer binary format (PPB):
*Fixed checksum calculation (the packet header is part of the checksum)
*Allow for packets up to 64 kB
*Skip over possible ASCII prologue/garbage before the PPB header