### PR TITLE
Fix COE output

### DIFF
--- a/srecord/output/file/coe.cc
+++ b/srecord/output/file/coe.cc
@@ -205,6 +205,7 @@ srecord::output_file_coe::write(const srecord::record &record)
             )
                 fatal_alignment_error(width_in_bytes);
 
+            address += len;
             for (unsigned j = 0; j < len; ++j)
             {
                 if (got_data && (j % width_in_bytes) == 0)


### PR DESCRIPTION
As already posted to the srecord-users mailing list [on 2019-03-31](https://sourceforge.net/p/srecord/mailman/message/36627198/), here is a patch that fixes output in COE format. Currently, the input data pointer increases correctly, but the output data pointer never does, which is interpreted as a hole in input data.

Since this is the only repository I found that could possibly still be maintained, I'll leave a pull request here for others (or myself) to stumble upon later.